### PR TITLE
Fix installer/docs consistency and skill description parsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,10 @@ python3 --version
 
 ```
 hooks/log-operations.py       # PostToolUse hook (data collection)
-commands/analyze-patterns.md  # /analyze-patterns skill (English)
-commands/analyze-patterns.zh-CN.md  # /analyze-patterns skill (Chinese)
+scripts/pre-analyze.py        # Pre-analysis engine (summary + pattern extraction)
+skills/analyze-patterns/SKILL.md  # /analyze-patterns skill (current format)
+commands/analyze-patterns.md  # Legacy command (backward compatibility)
+commands/analyze-patterns.zh-CN.md  # Legacy Chinese translation
 install.sh                    # Installer
 uninstall.sh                  # Uninstaller
 ```
@@ -44,9 +46,11 @@ uninstall.sh                  # Uninstaller
    - Ensure it still works with Python 3.8+ and only uses the stdlib.
    - Verify the hook does not raise exceptions under any input (the blanket `try/except` in `main()` must remain).
    - Test manually: pipe sample JSON to stdin and confirm a valid JSONL line is appended.
-5. If you modify `analyze-patterns.md`:
-   - Keep the Chinese translation (`analyze-patterns.zh-CN.md`) in sync, or note in the PR that translation is needed.
-6. Write a clear PR description explaining **what** changed and **why**.
+5. If you modify `skills/analyze-patterns/SKILL.md`:
+   - Keep behavior aligned with the legacy command files (`commands/analyze-patterns*.md`) when relevant, or clearly note intentional divergence in the PR.
+6. If you modify any user-facing English/Chinese docs or command/skill instructions:
+   - Keep translations in sync, or note in the PR that translation follow-up is needed.
+7. Write a clear PR description explaining **what** changed and **why**.
 
 ## Coding Guidelines
 

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ What it does:
   1. Copies hooks/log-operations.py to ~/.claude/hooks/
   2. Copies scripts/pre-analyze.py to ~/.claude/scripts/
   3. Copies skills/analyze-patterns/SKILL.md to ~/.claude/skills/analyze-patterns/
-  4. Copies commands/analyze-patterns.md to ~/.claude/commands/ (legacy)
+  4. Removes legacy command ~/.claude/commands/analyze-patterns.md (if present)
   5. Registers the PostToolUse hook in ~/.claude/settings.json
 
 Requirements:

--- a/scripts/pre-analyze.py
+++ b/scripts/pre-analyze.py
@@ -23,6 +23,52 @@ COMMANDS_DIR = Path.home() / ".claude" / "commands"
 SKILLS_DIR = Path.home() / ".claude" / "skills"
 
 
+def _strip_wrapping_quotes(value):
+    if len(value) >= 2 and (
+        (value[0] == '"' and value[-1] == '"')
+        or (value[0] == "'" and value[-1] == "'")
+    ):
+        return value[1:-1].strip()
+    return value
+
+
+def _first_content_line(content, skip_prefixes):
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(stripped.startswith(prefix) for prefix in skip_prefixes):
+            continue
+        return stripped[:100]
+    return ""
+
+
+def _extract_skill_description(content):
+    body = content
+    lines = content.splitlines()
+
+    # Parse optional YAML frontmatter and prefer `description:` there.
+    if lines and lines[0].strip() == "---":
+        end_idx = None
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                end_idx = i
+                break
+
+        if end_idx is not None:
+            frontmatter_lines = lines[1:end_idx]
+            for line in frontmatter_lines:
+                stripped = line.strip()
+                if stripped.lower().startswith("description:"):
+                    desc = stripped.split(":", 1)[1].strip()
+                    desc = _strip_wrapping_quotes(desc)
+                    if desc:
+                        return desc[:100]
+            body = "\n".join(lines[end_idx + 1:])
+
+    return _first_content_line(body, skip_prefixes=("#", "!"))
+
+
 def parse_ts(ts_str):
     try:
         ts_str = ts_str.rstrip("Z") + "+00:00" if ts_str.endswith("Z") else ts_str
@@ -82,11 +128,7 @@ def scan_skills():
                 if f.suffix == ".md" and f.is_file():
                     try:
                         content = f.read_text(encoding="utf-8", errors="replace")[:500]
-                        desc = next(
-                            (l.strip()[:100] for l in content.split("\n")
-                             if l.strip() and not l.strip().startswith("#")),
-                            "",
-                        )
+                        desc = _first_content_line(content, skip_prefixes=("#",))
                     except OSError:
                         desc = ""
                     skills[f.stem] = desc
@@ -95,11 +137,7 @@ def scan_skills():
                 if sd.is_dir() and (sd / "SKILL.md").exists():
                     try:
                         content = (sd / "SKILL.md").read_text(encoding="utf-8", errors="replace")[:500]
-                        desc = next(
-                            (l.strip()[:100] for l in content.split("\n")
-                             if l.strip() and not l.strip().startswith(("#", "!"))),
-                            "",
-                        )
+                        desc = _extract_skill_description(content)
                     except OSError:
                         desc = ""
                     skills[sd.name] = desc


### PR DESCRIPTION
## Summary
This PR delivers three focused fixes:

1. `install.sh`: update help text to match current behavior (remove legacy command if present)
2. `CONTRIBUTING.md`: refresh project structure and contribution flow for current `skills/` + `scripts/` layout
3. `scripts/pre-analyze.py`: improve `SKILL.md` description extraction by preferring YAML frontmatter `description:` and falling back to first content line

Closes #1

## Validation
- `python3 -m py_compile scripts/pre-analyze.py`
- `bash -n install.sh`
- `bash -n uninstall.sh`
